### PR TITLE
Add LDO 42STH48-2504AC

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -53,6 +53,14 @@ var motorPresets = [
 		ratedCurrent: 2000,
 		resistance: 1.4,
 		inductance: 3.0
+	},
+	{
+		name: "LDO 42STH48-2504AC",
+		stepAngle: 1.8,
+		ratedTorque: 55,
+		ratedCurrent: 2500,
+		resistance: 1.2,
+		inductance: 1.5
 	}
 ];
 


### PR DESCRIPTION
The LDO 42STH48-2504AC is a common motor used in a variety of currently popular printer kits. This adds its presets for easy reference.