### PR TITLE
changed dead link

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 								<li><a href="https://github.com/Duet3D/DuetWebControl">DuetWebControl on GitHub</a></li>
 							</ul>
 						</li>
-						<li><a href="https://duet3d.dozuki.com">Documentation</a></li>
+						<li><a href="https://docs.duet3d.com/en/User_manual/RepRapFirmware">Documentation</a></li>
 						<li><a href="https://www.duet3d.com/forum">Forum</a></li>
 						<li><a href="https://www.duet3d.com/products">Compatible Boards</a></li>
 					</ul>


### PR DESCRIPTION
I noticed the link to the documentation lead to the now deactivated dozuki page and changed it.